### PR TITLE
Empty files shouldn't explode

### DIFF
--- a/lib/prefixer.js
+++ b/lib/prefixer.js
@@ -50,6 +50,11 @@ module.exports = function(code, options, done) {
     // Don't know why I have to walk the tokens manually instead of calling
     // rocambole.walk(), but whatever!
     token = ast.startToken;
+
+    // No end token? We can't help you
+    if(!ast.endToken) {
+       return done(null, code);
+    }
     
     while(token !== ast.endToken.next) {
         var str;

--- a/test/prefixer.js
+++ b/test/prefixer.js
@@ -29,6 +29,20 @@ describe("JS Prefixer", function() {
                 }
             );
         });
+
+        it("should work on empty files", function(done) {
+            prefixer(
+                fs.readFileSync("./test/specimens/empty.js", "utf8"),
+                { prefix : "//f.com" },
+                function(err, code) {
+                    assert.ifError(err);
+                    
+                    assert(code.length === 0);
+
+                    done();
+                }
+            );
+        });
         
         it("should update strings & maintain comments", function(done) {
             prefixer(


### PR DESCRIPTION
Check for `ast.endToken` to be truthy before trying to iterate tokens.